### PR TITLE
Improve analyzer performance for bundles with many assets

### DIFF
--- a/.changeset/calm-assets-match.md
+++ b/.changeset/calm-assets-match.md
@@ -1,0 +1,5 @@
+---
+"webpack-bundle-analyzer": patch
+---
+
+Improve report generation performance for compilations with many assets.

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -143,6 +143,54 @@ function getBundleModules(bundleStats) {
   });
 }
 
+/**
+ * @typedef {{ module: StatsModule, index: number }} IndexedModule
+ */
+
+/**
+ * @param {StatsModule[]} modules modules
+ * @returns {Map<string | number, IndexedModule[]>} modules indexed by chunk ID
+ */
+function getModulesByChunk(modules) {
+  /** @type {Map<string | number, IndexedModule[]>} */
+  const modulesByChunk = new Map();
+
+  for (const [index, module] of modules.entries()) {
+    for (const chunk of module.chunks || []) {
+      let chunkModules = modulesByChunk.get(chunk);
+
+      if (!chunkModules) {
+        chunkModules = [];
+        modulesByChunk.set(chunk, chunkModules);
+      }
+
+      chunkModules.push({ module, index });
+    }
+  }
+
+  return modulesByChunk;
+}
+
+/**
+ * @param {StatsAsset} statsAsset stats asset
+ * @param {Map<string | number, IndexedModule[]>} modulesByChunk modules indexed by chunk ID
+ * @returns {StatsModule[]} modules belonging to the asset in their original order
+ */
+function getAssetModulesByChunk(statsAsset, modulesByChunk) {
+  /** @type {Map<StatsModule, IndexedModule>} */
+  const indexedModules = new Map();
+
+  for (const chunk of statsAsset.chunks || []) {
+    for (const indexedModule of modulesByChunk.get(chunk) || []) {
+      indexedModules.set(indexedModule.module, indexedModule);
+    }
+  }
+
+  return [...indexedModules.values()]
+    .toSorted((a, b) => a.index - b.index)
+    .map(({ module }) => module);
+}
+
 /** @typedef {Record<string, Record<string, boolean>>} ChunkToInitialByEntrypoint */
 
 /**
@@ -316,16 +364,28 @@ function getViewerData(bundleStats, bundleDir, opts) {
 
   /** @typedef {{ size: number, parsedSize?: number, gzipSize?: number, brotliSize?: number, zstdSize?: number, modules: StatsModule[], tree: Folder }} Asset */
 
+  const rootModules = getBundleModules(bundleStats);
+  const rootModulesByChunk = getModulesByChunk(rootModules);
+
   const assets = bundleStats.assets.reduce((result, statAsset) => {
-    // If asset is a childAsset, then calculate appropriate bundle modules by looking through stats.children
-    const assetBundles = statAsset.isChild
-      ? getChildAssetBundles(bundleStats, statAsset.name)
-      : bundleStats;
     /** @type {StatsModule[]} */
-    const modules = assetBundles
-      ? // @ts-expect-error TODO looks like we have a bug with child compilation parsing, need to add test cases
-        getBundleModules(assetBundles)
-      : [];
+    let assetModules;
+
+    if (statAsset.isChild) {
+      // Preserve child-compilation matching because child assets use a different module list.
+      const assetBundles = getChildAssetBundles(bundleStats, statAsset.name);
+      /** @type {StatsModule[]} */
+      const modules = assetBundles
+        ? // @ts-expect-error TODO looks like we have a bug with child compilation parsing, need to add test cases
+          getBundleModules(assetBundles)
+        : [];
+      assetModules = modules.filter((statModule) =>
+        assetHasModule(statAsset, statModule),
+      );
+    } else {
+      assetModules = getAssetModulesByChunk(statAsset, rootModulesByChunk);
+    }
+
     const asset = (result[statAsset.name] = /** @type {Asset} */ ({
       size: statAsset.size,
     }));
@@ -349,12 +409,6 @@ function getViewerData(bundleStats, bundleDir, opts) {
         asset.zstdSize = getCompressedSize("zstd", assetSources.src);
       }
     }
-
-    // Picking modules from current bundle script
-    /** @type {StatsModule[]} */
-    let assetModules = (modules || []).filter((statModule) =>
-      assetHasModule(statAsset, statModule),
-    );
 
     // Adding parsed sources
     if (parsedModules) {

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -155,8 +155,8 @@ function getModulesByChunk(modules) {
   /** @type {Map<string | number, IndexedModule[]>} */
   const modulesByChunk = new Map();
 
-  for (const [index, module] of modules.entries()) {
-    for (const chunk of module.chunks || []) {
+  for (const [index, statsModule] of modules.entries()) {
+    for (const chunk of statsModule.chunks || []) {
       let chunkModules = modulesByChunk.get(chunk);
 
       if (!chunkModules) {
@@ -164,7 +164,7 @@ function getModulesByChunk(modules) {
         modulesByChunk.set(chunk, chunkModules);
       }
 
-      chunkModules.push({ module, index });
+      chunkModules.push({ module: statsModule, index });
     }
   }
 

--- a/test/analyzer.js
+++ b/test/analyzer.js
@@ -3,7 +3,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const url = require("node:url");
 const puppeteer = require("puppeteer");
-const { getViewerData } = require("../lib/analyzer");
+const { getViewerData } = require("../src/analyzer");
 const { isZstdSupported } = require("../src/sizeUtils");
 
 let browser;

--- a/test/analyzer.js
+++ b/test/analyzer.js
@@ -3,6 +3,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const url = require("node:url");
 const puppeteer = require("puppeteer");
+const { getViewerData } = require("../lib/analyzer");
 const { isZstdSupported } = require("../src/sizeUtils");
 
 let browser;
@@ -131,6 +132,74 @@ describe("Analyzer", () => {
     expect(chartData).toMatchObject(
       require("./stats/with-modules-in-chunks/expected-chart-data"),
     );
+  });
+
+  it("should preserve module order and deduplicate modules for multi-chunk assets", () => {
+    const chartData = getViewerData(
+      {
+        assets: [
+          {
+            name: "multi-chunk.js",
+            size: 5,
+            chunks: ["string-chunk", 1],
+          },
+        ],
+        chunks: [],
+        entrypoints: {},
+        modules: [
+          {
+            id: 1,
+            identifier: "./numeric.js",
+            name: "./numeric.js",
+            size: 1,
+            chunks: [1],
+          },
+          {
+            id: 2,
+            identifier: "./shared.js",
+            name: "./shared.js",
+            size: 1,
+            chunks: [1, "string-chunk"],
+          },
+          {
+            id: 3,
+            identifier: "./string.js",
+            name: "./string.js",
+            size: 1,
+            chunks: ["string-chunk"],
+          },
+          {
+            id: 4,
+            identifier: "./unchunked.js",
+            name: "./unchunked.js",
+            size: 1,
+            chunks: [],
+          },
+          {
+            id: 1,
+            identifier: "./duplicate-id.js",
+            name: "./duplicate-id.js",
+            size: 1,
+            chunks: ["string-chunk"],
+          },
+          {
+            id: 5,
+            identifier: "webpack/runtime/test",
+            name: "webpack/runtime/test",
+            moduleType: "runtime",
+            size: 1,
+            chunks: [1],
+          },
+        ],
+      },
+      null,
+    );
+
+    expect(chartData[0].groups.map((group) => group.label)).toEqual([
+      "numeric.js",
+      "shared.js",
+      "string.js",
+    ]);
   });
 
   it("should record accurate byte lengths for sources with special chars", async () => {


### PR DESCRIPTION
## Problem

`getViewerData()` rebuilt the root compilation's module list and scanned every module once per analyzed asset. For ordinary root assets, this made module selection roughly O(assets × modules), even though every asset used the same compilation module list.

No matching public issue or pull request was found for this report-generation bottleneck.

## Solution

- Build the deduplicated, runtime-filtered root module list once.
- Index root modules by numeric or string chunk ID.
- Gather only modules belonging to an asset's referenced chunks.
- Deduplicate modules shared by multiple chunks and sort candidates by their original module-list index.
- Keep child-compilation assets on the existing conservative full-scan path.

The public API and chart-data schema are unchanged.

## Complexity and correctness

Root asset selection changes from repeatedly scanning the complete module list for every asset to a one-time O(module chunk memberships) index plus per-asset candidate gathering and O(k log k) ordering, where k is the number of candidate modules for that asset.

Indexing occurs after the existing runtime-module and duplicate module-ID filtering, so those semantics remain unchanged. Exact `Map` keys preserve the distinction between numeric and string chunk IDs. Candidate deduplication handles modules shared across referenced chunks, while index sorting preserves the original global module order. Modules without chunks remain excluded from chunk-backed assets. Child-compilation matching is intentionally unchanged.

## Performance

Observed on one large workload (these measurements were not rerun as part of this pull request):

- 1,486 analyzed JavaScript assets
- about 8.58 MB serialized chart data and 8.89 MB static HTML
- 25,620 compression operations over about 198 MB of input
- analyzer report generation: 20.8–22.2 seconds before and about 6.2 seconds after the prototype
- end-to-end raw samples: 100.63 and 93.40 seconds before; 74.46 and 73.61 seconds after
- midpoint improvement: about 22.98 seconds / 23.7%

Peak memory remained around 11–12 GB; this change does not claim a memory improvement. Stats conversion, measured separately at 7.3–8.3 seconds, is outside this optimization.

A local synthetic check used 1,486 assets and 30,000 modules with one chunk assignment per module. Three sequential `getViewerData()` runs measured 2,206.6, 2,189.5, and 2,174.8 ms before; 45.1, 43.0, and 32.0 ms after. This is an illustrative module-selection comparison, not a repository benchmark or a wall-time assertion.

## Tests

Added focused generated-chart-data coverage for an asset referencing numeric and string chunk IDs. The fixture deliberately traverses chunks in a different order from the global module list, shares a module across both chunks, includes an unchunked module, a duplicate module ID, and a runtime module. The assertion verifies original output order and single inclusion of the shared module.

Existing analyzer fixtures continue to cover modules embedded in chunks, multiple entrypoints, worker/child compilations, Webpack 5 single and multiple entries, and concatenated modules.

## Validation

- `npm test -- --runTestsByPath test/analyzer.js --silent` — 27 passed, 4 skipped
- `npm test -- --silent` — 129 passed, 4 skipped
- `npm run lint` — ESLint, TypeScript, and Prettier checks passed
- `npm run build` — analyzer and production viewer builds passed
- Generated a static multi-chunk report, opened it in a browser, and verified `numeric.js`, `shared.js`, and `string.js` appeared once in original module order