### PR TITLE
fix: parse Webpack 5 module maps nested in UMD wrappers

### DIFF
--- a/.changeset/bright-bundles-parse.md
+++ b/.changeset/bright-bundles-parse.md
@@ -1,0 +1,5 @@
+---
+"webpack-bundle-analyzer": patch
+---
+
+Parse Webpack 5 module maps nested in UMD wrappers, using bundle module IDs and Webpack runtime structure to choose among IIFE candidates.

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -347,11 +347,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
   const assetModuleInfo = new Map();
 
   for (const statAsset of bundleStats.assets) {
-    const modules = getAssetModules(
-      bundleStats,
-      statAsset,
-      rootModulesByChunk,
-    );
+    const modules = getAssetModules(bundleStats, statAsset, rootModulesByChunk);
     const expectedModuleIds = modules.reduce((moduleIds, statsModule) => {
       if (
         typeof statsModule.id === "string" ||

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -191,29 +191,6 @@ function getAssetModulesByChunk(statsAsset, modulesByChunk) {
     .map(({ module }) => module);
 }
 
-/**
- * @param {StatsCompilation} bundleStats bundle stats
- * @param {StatsAsset} statAsset stats asset
- * @param {Map<string | number, IndexedModule[]>} rootModulesByChunk root modules indexed by chunk ID
- * @returns {StatsModule[]} modules in asset
- */
-function getAssetModules(bundleStats, statAsset, rootModulesByChunk) {
-  if (!statAsset.isChild) {
-    return getAssetModulesByChunk(statAsset, rootModulesByChunk);
-  }
-
-  const assetBundles = getChildAssetBundles(bundleStats, statAsset.name);
-  /** @type {StatsModule[]} */
-  const modules = assetBundles
-    ? // @ts-expect-error TODO looks like we have a bug with child compilation parsing, need to add test cases
-      getBundleModules(assetBundles)
-    : [];
-
-  return modules.filter((statsModule) =>
-    assetHasModule(statAsset, statsModule),
-  );
-}
-
 /** @typedef {Record<string, Record<string, boolean>>} ChunkToInitialByEntrypoint */
 
 /**
@@ -342,24 +319,16 @@ function getViewerData(bundleStats, bundleDir, opts) {
 
   const rootModules = getBundleModules(bundleStats);
   const rootModulesByChunk = getModulesByChunk(rootModules);
-
-  /** @type {Map<StatsAsset, { modules: StatsModule[], expectedModuleIds: (string | number)[] }>} */
-  const assetModuleInfo = new Map();
+  /** @type {Map<StatsAsset, StatsModule[]>} */
+  const rootAssetModules = new Map();
 
   for (const statAsset of bundleStats.assets) {
-    const modules = getAssetModules(bundleStats, statAsset, rootModulesByChunk);
-    const expectedModuleIds = modules.reduce((moduleIds, statsModule) => {
-      if (
-        typeof statsModule.id === "string" ||
-        typeof statsModule.id === "number"
-      ) {
-        moduleIds.push(statsModule.id);
-      }
-
-      return moduleIds;
-    }, /** @type {(string | number)[]} */ ([]));
-
-    assetModuleInfo.set(statAsset, { modules, expectedModuleIds });
+    if (!statAsset.isChild) {
+      rootAssetModules.set(
+        statAsset,
+        getAssetModulesByChunk(statAsset, rootModulesByChunk),
+      );
+    }
   }
 
   // Trying to parse bundle assets and get real module sizes if `bundleDir` is provided
@@ -374,8 +343,21 @@ function getViewerData(bundleStats, bundleDir, opts) {
 
     for (const statAsset of bundleStats.assets) {
       const assetFile = path.join(bundleDir, statAsset.name);
-      const expectedModuleIds =
-        assetModuleInfo.get(statAsset)?.expectedModuleIds || [];
+      const expectedModuleIds = statAsset.isChild
+        ? []
+        : /** @type {StatsModule[]} */ (rootAssetModules.get(statAsset)).reduce(
+            (moduleIds, statsModule) => {
+              if (
+                typeof statsModule.id === "string" ||
+                typeof statsModule.id === "number"
+              ) {
+                moduleIds.push(statsModule.id);
+              }
+
+              return moduleIds;
+            },
+            /** @type {(string | number)[]} */ ([]),
+          );
       let bundleInfo;
 
       try {
@@ -413,6 +395,26 @@ function getViewerData(bundleStats, bundleDir, opts) {
   /** @typedef {{ size: number, parsedSize?: number, gzipSize?: number, brotliSize?: number, zstdSize?: number, modules: StatsModule[], tree: Folder }} Asset */
 
   const assets = bundleStats.assets.reduce((result, statAsset) => {
+    /** @type {StatsModule[]} */
+    let assetModules;
+
+    if (statAsset.isChild) {
+      // Preserve child-compilation matching because child assets use a different module list.
+      const assetBundles = getChildAssetBundles(bundleStats, statAsset.name);
+      /** @type {StatsModule[]} */
+      const modules = assetBundles
+        ? // @ts-expect-error TODO looks like we have a bug with child compilation parsing, need to add test cases
+          getBundleModules(assetBundles)
+        : [];
+      assetModules = modules.filter((statModule) =>
+        assetHasModule(statAsset, statModule),
+      );
+    } else {
+      assetModules = /** @type {StatsModule[]} */ (
+        rootAssetModules.get(statAsset)
+      );
+    }
+
     const asset = (result[statAsset.name] = /** @type {Asset} */ ({
       size: statAsset.size,
     }));
@@ -436,10 +438,6 @@ function getViewerData(bundleStats, bundleDir, opts) {
         asset.zstdSize = getCompressedSize("zstd", assetSources.src);
       }
     }
-
-    // Picking modules from current bundle script
-    /** @type {StatsModule[]} */
-    let assetModules = assetModuleInfo.get(statAsset)?.modules || [];
 
     // Adding parsed sources
     if (parsedModules) {

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -191,6 +191,29 @@ function getAssetModulesByChunk(statsAsset, modulesByChunk) {
     .map(({ module }) => module);
 }
 
+/**
+ * @param {StatsCompilation} bundleStats bundle stats
+ * @param {StatsAsset} statAsset stats asset
+ * @param {Map<string | number, IndexedModule[]>} rootModulesByChunk root modules indexed by chunk ID
+ * @returns {StatsModule[]} modules in asset
+ */
+function getAssetModules(bundleStats, statAsset, rootModulesByChunk) {
+  if (!statAsset.isChild) {
+    return getAssetModulesByChunk(statAsset, rootModulesByChunk);
+  }
+
+  const assetBundles = getChildAssetBundles(bundleStats, statAsset.name);
+  /** @type {StatsModule[]} */
+  const modules = assetBundles
+    ? // @ts-expect-error TODO looks like we have a bug with child compilation parsing, need to add test cases
+      getBundleModules(assetBundles)
+    : [];
+
+  return modules.filter((statsModule) =>
+    assetHasModule(statAsset, statsModule),
+  );
+}
+
 /** @typedef {Record<string, Record<string, boolean>>} ChunkToInitialByEntrypoint */
 
 /**
@@ -317,6 +340,32 @@ function getViewerData(bundleStats, bundleDir, opts) {
     );
   });
 
+  const rootModules = getBundleModules(bundleStats);
+  const rootModulesByChunk = getModulesByChunk(rootModules);
+
+  /** @type {Map<StatsAsset, { modules: StatsModule[], expectedModuleIds: (string | number)[] }>} */
+  const assetModuleInfo = new Map();
+
+  for (const statAsset of bundleStats.assets) {
+    const modules = getAssetModules(
+      bundleStats,
+      statAsset,
+      rootModulesByChunk,
+    );
+    const expectedModuleIds = modules.reduce((moduleIds, statsModule) => {
+      if (
+        typeof statsModule.id === "string" ||
+        typeof statsModule.id === "number"
+      ) {
+        moduleIds.push(statsModule.id);
+      }
+
+      return moduleIds;
+    }, /** @type {(string | number)[]} */ ([]));
+
+    assetModuleInfo.set(statAsset, { modules, expectedModuleIds });
+  }
+
   // Trying to parse bundle assets and get real module sizes if `bundleDir` is provided
   /** @type {Record<string, { src: string, runtimeSrc: string }> | null} */
   let bundlesSources = null;
@@ -329,11 +378,14 @@ function getViewerData(bundleStats, bundleDir, opts) {
 
     for (const statAsset of bundleStats.assets) {
       const assetFile = path.join(bundleDir, statAsset.name);
+      const expectedModuleIds =
+        assetModuleInfo.get(statAsset)?.expectedModuleIds || [];
       let bundleInfo;
 
       try {
         bundleInfo = parseBundle(assetFile, {
           sourceType: statAsset.info.javascriptModule ? "module" : "script",
+          expectedModuleIds,
         });
       } catch (err) {
         const msg =
@@ -364,28 +416,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
 
   /** @typedef {{ size: number, parsedSize?: number, gzipSize?: number, brotliSize?: number, zstdSize?: number, modules: StatsModule[], tree: Folder }} Asset */
 
-  const rootModules = getBundleModules(bundleStats);
-  const rootModulesByChunk = getModulesByChunk(rootModules);
-
   const assets = bundleStats.assets.reduce((result, statAsset) => {
-    /** @type {StatsModule[]} */
-    let assetModules;
-
-    if (statAsset.isChild) {
-      // Preserve child-compilation matching because child assets use a different module list.
-      const assetBundles = getChildAssetBundles(bundleStats, statAsset.name);
-      /** @type {StatsModule[]} */
-      const modules = assetBundles
-        ? // @ts-expect-error TODO looks like we have a bug with child compilation parsing, need to add test cases
-          getBundleModules(assetBundles)
-        : [];
-      assetModules = modules.filter((statModule) =>
-        assetHasModule(statAsset, statModule),
-      );
-    } else {
-      assetModules = getAssetModulesByChunk(statAsset, rootModulesByChunk);
-    }
-
     const asset = (result[statAsset.name] = /** @type {Asset} */ ({
       size: statAsset.size,
     }));
@@ -409,6 +440,10 @@ function getViewerData(bundleStats, bundleDir, opts) {
         asset.zstdSize = getCompressedSize("zstd", assetSources.src);
       }
     }
+
+    // Picking modules from current bundle script
+    /** @type {StatsModule[]} */
+    let assetModules = assetModuleInfo.get(statAsset)?.modules || [];
 
     // Adding parsed sources
     if (parsedModules) {

--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -151,7 +151,7 @@ function getModuleLocation(node) {
 }
 
 /** @typedef {Record<number, Location>} ModulesLocations */
-/** @typedef {{ locations: ModulesLocations, hasWebpackRuntime: boolean, isTopLevel: boolean, start: number }} Webpack5IIFECandidate */
+/** @typedef {{ locations: ModulesLocations, hasWebpackRuntime: boolean, isTopLevel: boolean }} Webpack5IIFECandidate */
 
 /**
  * @param {Expression | SpreadElement} node node
@@ -319,7 +319,6 @@ function getWebpack5IIFEModulesCandidate(node, isTopLevel) {
               declaration.id.name,
             ),
           isTopLevel,
-          start: node.start,
         };
       }
     }
@@ -329,18 +328,17 @@ function getWebpack5IIFEModulesCandidate(node, isTopLevel) {
 }
 
 /**
- * @param {Webpack5IIFECandidate} candidateA first candidate
- * @param {Webpack5IIFECandidate} candidateB second candidate
- * @returns {number} candidate sort order
+ * @param {Webpack5IIFECandidate[]} candidates candidates
+ * @returns {Webpack5IIFECandidate | null} selected candidate
  */
-function compareWebpack5IIFECandidates(candidateA, candidateB) {
+function selectWebpack5IIFECandidate(candidates) {
   return (
-    Number(candidateB.hasWebpackRuntime) -
-      Number(candidateA.hasWebpackRuntime) ||
-    Number(candidateB.isTopLevel) - Number(candidateA.isTopLevel) ||
-    Object.keys(candidateB.locations).length -
-      Object.keys(candidateA.locations).length ||
-    candidateA.start - candidateB.start
+    candidates.find(
+      (candidate) => candidate.hasWebpackRuntime && candidate.isTopLevel,
+    ) ||
+    candidates.find((candidate) => candidate.hasWebpackRuntime) ||
+    candidates.find((candidate) => candidate.isTopLevel) ||
+    null
   );
 }
 
@@ -366,37 +364,23 @@ function selectWebpack5IIFEModulesLocations(candidates, expectedModuleIds) {
       .toSorted(
         (candidateA, candidateB) =>
           candidateB.expectedIdsIntersection -
-            candidateA.expectedIdsIntersection ||
-          compareWebpack5IIFECandidates(
-            candidateA.candidate,
-            candidateB.candidate,
-          ),
+          candidateA.expectedIdsIntersection,
       );
 
     if (rankedCandidates[0].expectedIdsIntersection > 0) {
-      return rankedCandidates[0].candidate.locations;
+      const bestCandidates = rankedCandidates
+        .filter(
+          (rankedCandidate) =>
+            rankedCandidate.expectedIdsIntersection ===
+            rankedCandidates[0].expectedIdsIntersection,
+        )
+        .map((rankedCandidate) => rankedCandidate.candidate);
+
+      return selectWebpack5IIFECandidate(bestCandidates)?.locations || null;
     }
   }
 
-  const webpackCandidates = candidates
-    .filter((candidate) => candidate.hasWebpackRuntime)
-    .toSorted(
-      (candidateA, candidateB) =>
-        Number(candidateB.isTopLevel) - Number(candidateA.isTopLevel) ||
-        candidateA.start - candidateB.start ||
-        Object.keys(candidateB.locations).length -
-          Object.keys(candidateA.locations).length,
-    );
-
-  if (webpackCandidates.length > 0) {
-    return webpackCandidates[0].locations;
-  }
-
-  const topLevelCandidates = candidates
-    .filter((candidate) => candidate.isTopLevel)
-    .toSorted((candidateA, candidateB) => candidateA.start - candidateB.start);
-
-  return topLevelCandidates[0]?.locations || null;
+  return selectWebpack5IIFECandidate(candidates)?.locations || null;
 }
 
 /**

--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -151,6 +151,7 @@ function getModuleLocation(node) {
 }
 
 /** @typedef {Record<number, Location>} ModulesLocations */
+/** @typedef {{ locations: ModulesLocations, hasWebpackRuntime: boolean, isTopLevel: boolean, start: number }} Webpack5IIFECandidate */
 
 /**
  * @param {Expression | SpreadElement} node node
@@ -216,27 +217,186 @@ function getModulesLocations(node) {
 
 /**
  * @param {ExpressionStatement} node node
- * @returns {boolean} true when IIFE, otherwise false
+ * @returns {CallExpression | null} IIFE call expression
  */
-function isIIFE(node) {
+function getIIFECallExpression(node) {
+  if (node.expression.type === "CallExpression") {
+    return node.expression;
+  }
+
+  if (
+    node.expression.type === "UnaryExpression" &&
+    node.expression.argument.type === "CallExpression"
+  ) {
+    return node.expression.argument;
+  }
+
+  return null;
+}
+
+/**
+ * @param {Node} node node
+ * @param {string} modulesVariableName modules variable name
+ * @returns {boolean} true when the node calls a module wrapper
+ */
+function callsModulesMap(node, modulesVariableName) {
+  let callsModule = false;
+
+  walk.simple(node, {
+    CallExpression(callExpression) {
+      const { callee } = callExpression;
+
+      if (
+        callee.type === "MemberExpression" &&
+        ((callee.object.type === "Identifier" &&
+          callee.object.name === modulesVariableName) ||
+          (callee.object.type === "MemberExpression" &&
+            callee.object.object.type === "Identifier" &&
+            callee.object.object.name === modulesVariableName))
+      ) {
+        callsModule = true;
+      }
+    },
+  });
+
+  return callsModule;
+}
+
+/**
+ * @param {import("acorn").BlockStatement} body body
+ * @param {import("acorn").VariableDeclaration} modulesDeclaration modules declaration
+ * @param {string} modulesVariableName modules variable name
+ * @returns {boolean} true when the candidate contains Webpack module loading
+ */
+function hasWebpackModulesRuntime(
+  body,
+  modulesDeclaration,
+  modulesVariableName,
+) {
+  const declarationIndex = body.body.indexOf(modulesDeclaration);
+
+  return body.body
+    .slice(declarationIndex + 1)
+    .some((statement) => callsModulesMap(statement, modulesVariableName));
+}
+
+/**
+ * @param {CallExpression} node node
+ * @param {boolean} isTopLevel is top-level IIFE
+ * @returns {Webpack5IIFECandidate | null} modules candidate
+ */
+function getWebpack5IIFEModulesCandidate(node, isTopLevel) {
+  if (
+    node.arguments.length !== 0 ||
+    (node.callee.type !== "FunctionExpression" &&
+      node.callee.type !== "ArrowFunctionExpression") ||
+    node.callee.params.length !== 0 ||
+    node.callee.body.type !== "BlockStatement"
+  ) {
+    return null;
+  }
+
+  const firstVariableDeclaration = node.callee.body.body.find(
+    (node) => node.type === "VariableDeclaration",
+  );
+
+  if (firstVariableDeclaration) {
+    for (const declaration of firstVariableDeclaration.declarations) {
+      if (declaration.init && isModulesList(declaration.init)) {
+        const locations = getModulesLocations(declaration.init);
+
+        if (Object.keys(locations).length === 0) {
+          continue;
+        }
+
+        return {
+          locations,
+          hasWebpackRuntime:
+            declaration.id.type === "Identifier" &&
+            hasWebpackModulesRuntime(
+              node.callee.body,
+              firstVariableDeclaration,
+              declaration.id.name,
+            ),
+          isTopLevel,
+          start: node.start,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {Webpack5IIFECandidate} candidateA first candidate
+ * @param {Webpack5IIFECandidate} candidateB second candidate
+ * @returns {number} candidate sort order
+ */
+function compareWebpack5IIFECandidates(candidateA, candidateB) {
   return (
-    node.type === "ExpressionStatement" &&
-    (node.expression.type === "CallExpression" ||
-      (node.expression.type === "UnaryExpression" &&
-        node.expression.argument.type === "CallExpression"))
+    Number(candidateB.hasWebpackRuntime) -
+      Number(candidateA.hasWebpackRuntime) ||
+    Number(candidateB.isTopLevel) - Number(candidateA.isTopLevel) ||
+    Object.keys(candidateB.locations).length -
+      Object.keys(candidateA.locations).length ||
+    candidateA.start - candidateB.start
   );
 }
 
 /**
- * @param {ExpressionStatement} node node
- * @returns {Expression} IIFE call expression
+ * @param {Webpack5IIFECandidate[]} candidates candidates
+ * @param {(string | number)[] | undefined} expectedModuleIds expected module ids
+ * @returns {ModulesLocations | null} selected modules locations
  */
-function getIIFECallExpression(node) {
-  if (node.expression.type === "UnaryExpression") {
-    return node.expression.argument;
+function selectWebpack5IIFEModulesLocations(candidates, expectedModuleIds) {
+  if (candidates.length === 0) {
+    return null;
   }
 
-  return node.expression;
+  if (expectedModuleIds?.length) {
+    const expectedIds = new Set(expectedModuleIds.map(String));
+    const rankedCandidates = candidates
+      .map((candidate) => ({
+        candidate,
+        expectedIdsIntersection: Object.keys(candidate.locations).filter(
+          (moduleId) => expectedIds.has(moduleId),
+        ).length,
+      }))
+      .toSorted(
+        (candidateA, candidateB) =>
+          candidateB.expectedIdsIntersection -
+            candidateA.expectedIdsIntersection ||
+          compareWebpack5IIFECandidates(
+            candidateA.candidate,
+            candidateB.candidate,
+          ),
+      );
+
+    if (rankedCandidates[0].expectedIdsIntersection > 0) {
+      return rankedCandidates[0].candidate.locations;
+    }
+  }
+
+  const webpackCandidates = candidates
+    .filter((candidate) => candidate.hasWebpackRuntime)
+    .toSorted(
+      (candidateA, candidateB) =>
+        Number(candidateB.isTopLevel) - Number(candidateA.isTopLevel) ||
+        candidateA.start - candidateB.start ||
+        Object.keys(candidateB.locations).length -
+          Object.keys(candidateA.locations).length,
+    );
+
+  if (webpackCandidates.length > 0) {
+    return webpackCandidates[0].locations;
+  }
+
+  const topLevelCandidates = candidates
+    .filter((candidate) => candidate.isTopLevel)
+    .toSorted((candidateA, candidateB) => candidateA.start - candidateB.start);
+
+  return topLevelCandidates[0]?.locations || null;
 }
 
 /**
@@ -323,11 +483,11 @@ function isAsyncWebWorkerChunkExpression(node) {
 
 /**
  * @param {string} bundlePath bundle path
- * @param {{ sourceType: "script" | "module" }} opts options
+ * @param {{ sourceType?: "script" | "module", expectedModuleIds?: (string | number)[] }} opts options
  * @returns {{ modules: Modules, src: string, runtimeSrc: string }} parsed result
  */
 module.exports.parseBundle = function parseBundle(bundlePath, opts) {
-  const { sourceType = "script" } = opts || {};
+  const { sourceType = "script", expectedModuleIds } = opts || {};
 
   const content = fs.readFileSync(bundlePath, "utf8");
   const ast = acorn.parse(content, {
@@ -335,62 +495,26 @@ module.exports.parseBundle = function parseBundle(bundlePath, opts) {
     ecmaVersion: "latest",
   });
 
-  /** @type {{ locations: ModulesLocations | null, expressionStatementDepth: number }} */
+  /** @type {Set<CallExpression>} */
+  const topLevelIIFECalls = new Set();
+
+  for (const node of ast.body) {
+    if (node.type === "ExpressionStatement") {
+      const iifeCall = getIIFECallExpression(node);
+
+      if (iifeCall) {
+        topLevelIIFECalls.add(iifeCall);
+      }
+    }
+  }
+
+  /** @type {{ locations: ModulesLocations | null, webpack5IIFECandidates: Webpack5IIFECandidate[] }} */
   const walkState = {
     locations: null,
-    expressionStatementDepth: 0,
+    webpack5IIFECandidates: [],
   };
 
   walk.recursive(ast, walkState, {
-    ExpressionStatement(node, state, callback) {
-      if (state.locations) return;
-
-      state.expressionStatementDepth++;
-
-      if (
-        // Webpack 5 stores modules in the the top-level IIFE
-        state.expressionStatementDepth === 1 &&
-        ast.body.includes(node) &&
-        isIIFE(node)
-      ) {
-        const fn = getIIFECallExpression(node);
-
-        if (
-          fn.type === "CallExpression" &&
-          // It should not contain neither arguments
-          fn.arguments.length === 0 &&
-          (fn.callee.type === "FunctionExpression" ||
-            fn.callee.type === "ArrowFunctionExpression") &&
-          // ...nor parameters
-          fn.callee.params.length === 0 &&
-          fn.callee.body.type === "BlockStatement"
-        ) {
-          // Modules are stored in the very first variable declaration as hash
-          const firstVariableDeclaration = fn.callee.body.body.find(
-            (node) => node.type === "VariableDeclaration",
-          );
-
-          if (firstVariableDeclaration) {
-            for (const declaration of firstVariableDeclaration.declarations) {
-              if (declaration.init && isModulesList(declaration.init)) {
-                state.locations = getModulesLocations(declaration.init);
-
-                if (state.locations) {
-                  break;
-                }
-              }
-            }
-          }
-        }
-      }
-
-      if (!state.locations) {
-        callback(node.expression, state);
-      }
-
-      state.expressionStatementDepth--;
-    },
-
     AssignmentExpression(node, state) {
       if (state.locations) return;
 
@@ -417,6 +541,14 @@ module.exports.parseBundle = function parseBundle(bundlePath, opts) {
       if (state.locations) return;
 
       const args = node.arguments;
+      const webpack5IIFEModulesCandidate = getWebpack5IIFEModulesCandidate(
+        node,
+        topLevelIIFECalls.has(node),
+      );
+
+      if (webpack5IIFEModulesCandidate) {
+        state.webpack5IIFECandidates.push(webpack5IIFEModulesCandidate);
+      }
 
       // Main chunk with webpack loader.
       // Modules are stored in first argument:
@@ -472,11 +604,17 @@ module.exports.parseBundle = function parseBundle(bundlePath, opts) {
     },
   });
 
+  const modulesLocations =
+    walkState.locations ||
+    selectWebpack5IIFEModulesLocations(
+      walkState.webpack5IIFECandidates,
+      expectedModuleIds,
+    );
   /** @type {Modules} */
   const modules = {};
 
-  if (walkState.locations) {
-    for (const [id, loc] of Object.entries(walkState.locations)) {
+  if (modulesLocations) {
+    for (const [id, loc] of Object.entries(modulesLocations)) {
       modules[id] = content.slice(loc.start, loc.end);
     }
   }
@@ -484,6 +622,6 @@ module.exports.parseBundle = function parseBundle(bundlePath, opts) {
   return {
     modules,
     src: content,
-    runtimeSrc: getBundleRuntime(content, walkState.locations),
+    runtimeSrc: getBundleRuntime(content, modulesLocations),
   };
 };

--- a/test/analyzerUtils.js
+++ b/test/analyzerUtils.js
@@ -1,0 +1,68 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { getViewerData } = require("../src/analyzer");
+
+const BUNDLES_DIR = path.resolve(__dirname, "./bundles");
+
+describe("getViewerData", () => {
+  it("passes asset module ids when parsing competing Webpack 5 IIFEs", () => {
+    const bundleName = "webpack5UmdBundleWithDecoyIIFE";
+    const bundleFilename = `${bundleName}.js`;
+    const expectedModules = JSON.parse(
+      fs.readFileSync(`${BUNDLES_DIR}/${bundleName}.modules.json`),
+    ).modules;
+    const dependencyModule = {
+      id: 447,
+      identifier: "./src/dependency.js",
+      name: "./src/dependency.js",
+      size: 40,
+      chunks: [1],
+      depth: 1,
+    };
+    const entryModule = {
+      id: 956,
+      identifier: "./src/entry.js",
+      name: "./src/entry.js",
+      size: 80,
+      chunks: [1],
+      depth: 0,
+    };
+    let chunksAccessCount = 0;
+    const chunks = [
+      {
+        id: 1,
+        modules: [dependencyModule, entryModule],
+      },
+    ];
+    const stats = {
+      assets: [
+        {
+          type: "asset",
+          name: bundleFilename,
+          size: fs.statSync(`${BUNDLES_DIR}/${bundleFilename}`).size,
+          info: {
+            javascriptModule: false,
+          },
+          chunks: [1],
+        },
+      ],
+      get chunks() {
+        chunksAccessCount++;
+        return chunks;
+      },
+      entrypoints: {
+        main: {
+          name: "main",
+          assets: [{ name: bundleFilename }],
+        },
+      },
+    };
+
+    getViewerData(stats, BUNDLES_DIR);
+
+    expect(dependencyModule.parsedSrc).toBe(expectedModules[447]);
+    expect(entryModule.parsedSrc).toBe(expectedModules[956]);
+    expect(chunksAccessCount).toBe(1);
+  });
+});

--- a/test/analyzerUtils.js
+++ b/test/analyzerUtils.js
@@ -28,11 +28,18 @@ describe("getViewerData", () => {
       chunks: [1],
       depth: 0,
     };
+    const moduleWithoutId = {
+      identifier: "./src/no-id.js",
+      name: "./src/no-id.js",
+      size: 20,
+      chunks: [1],
+      depth: 1,
+    };
     let chunksAccessCount = 0;
     const chunks = [
       {
         id: 1,
-        modules: [dependencyModule, entryModule],
+        modules: [dependencyModule, entryModule, moduleWithoutId],
       },
     ];
     const stats = {
@@ -45,6 +52,16 @@ describe("getViewerData", () => {
             javascriptModule: false,
           },
           chunks: [1],
+        },
+        {
+          type: "asset",
+          name: "validWebpack5UmdBundle.js",
+          size: fs.statSync(`${BUNDLES_DIR}/validWebpack5UmdBundle.js`).size,
+          info: {
+            javascriptModule: false,
+          },
+          chunks: [2],
+          isChild: true,
         },
       ],
       get chunks() {

--- a/test/bundles/validWebpack5NestedModuleAccessor.js
+++ b/test/bundles/validWebpack5NestedModuleAccessor.js
@@ -1,0 +1,7 @@
+(() => {
+  var modules = {
+    123: () => "nested-module-accessor",
+  };
+
+  modules.default[123]();
+})();

--- a/test/bundles/validWebpack5NestedModuleAccessor.modules.json
+++ b/test/bundles/validWebpack5NestedModuleAccessor.modules.json
@@ -1,0 +1,5 @@
+{
+  "modules": {
+    "123": "() => \"nested-module-accessor\""
+  }
+}

--- a/test/bundles/validWebpack5UmdBundle.js
+++ b/test/bundles/validWebpack5UmdBundle.js
@@ -1,0 +1,68 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["FixtureLibrary"] = factory();
+	else
+		root["FixtureLibrary"] = factory();
+})(this, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 447
+(module) {
+
+module.exports = "fixture-dependency";
+
+
+/***/ },
+
+/***/ 956
+(module, __unused_webpack_exports, __webpack_require__) {
+
+const dependency = __webpack_require__(447);
+
+module.exports = { dependency };
+
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/************************************************************************/
+/******/
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __webpack_require__(956);
+/******/
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});

--- a/test/bundles/validWebpack5UmdBundle.modules.json
+++ b/test/bundles/validWebpack5UmdBundle.modules.json
@@ -1,0 +1,6 @@
+{
+  "modules": {
+    "447": "(module) {\n\nmodule.exports = \"fixture-dependency\";\n\n\n/***/ }",
+    "956": "(module, __unused_webpack_exports, __webpack_require__) {\n\nconst dependency = __webpack_require__(447);\n\nmodule.exports = { dependency };\n\n\n/***/ }"
+  }
+}

--- a/test/bundles/webpack5NestedModulesWithoutRuntime.js
+++ b/test/bundles/webpack5NestedModulesWithoutRuntime.js
@@ -1,0 +1,11 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+  root["FixtureLibrary"] = factory();
+})(this, () => {
+  return (() => {
+    var modules = {
+      123: () => "not-a-webpack-runtime",
+    };
+
+    return modules;
+  })();
+});

--- a/test/bundles/webpack5TopLevelModulesWithoutRuntime.js
+++ b/test/bundles/webpack5TopLevelModulesWithoutRuntime.js
@@ -1,0 +1,7 @@
+(() => {
+  var modules = {
+    123: () => "top-level-fallback",
+  };
+
+  return modules;
+})();

--- a/test/bundles/webpack5TopLevelModulesWithoutRuntime.js
+++ b/test/bundles/webpack5TopLevelModulesWithoutRuntime.js
@@ -1,7 +1,11 @@
+const marker = true;
+
 (() => {
   var modules = {
     123: () => "top-level-fallback",
   };
+
+  noop();
 
   return modules;
 })();

--- a/test/bundles/webpack5TopLevelModulesWithoutRuntime.modules.json
+++ b/test/bundles/webpack5TopLevelModulesWithoutRuntime.modules.json
@@ -1,0 +1,5 @@
+{
+  "modules": {
+    "123": "() => \"top-level-fallback\""
+  }
+}

--- a/test/bundles/webpack5UmdBundleWithDecoyIIFE.js
+++ b/test/bundles/webpack5UmdBundleWithDecoyIIFE.js
@@ -1,0 +1,70 @@
+(()=>{var emptyModules={};return emptyModules;})();
+(()=>{var decoyModules={999:()=>"decoy-not-webpack"};return decoyModules;})();
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["FixtureLibrary"] = factory();
+	else
+		root["FixtureLibrary"] = factory();
+})(this, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 447
+(module) {
+
+module.exports = "fixture-dependency";
+
+
+/***/ },
+
+/***/ 956
+(module, __unused_webpack_exports, __webpack_require__) {
+
+const dependency = __webpack_require__(447);
+
+module.exports = { dependency };
+
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __webpack_require__(956);
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});

--- a/test/bundles/webpack5UmdBundleWithDecoyIIFE.js
+++ b/test/bundles/webpack5UmdBundleWithDecoyIIFE.js
@@ -1,3 +1,4 @@
+(()=>{return "not-a-candidate";})();
 (()=>{var emptyModules={};return emptyModules;})();
 (()=>{var decoyModules={999:()=>"decoy-not-webpack"};return decoyModules;})();
 (function webpackUniversalModuleDefinition(root, factory) {

--- a/test/bundles/webpack5UmdBundleWithDecoyIIFE.js
+++ b/test/bundles/webpack5UmdBundleWithDecoyIIFE.js
@@ -35,7 +35,7 @@ module.exports = { dependency };
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -49,21 +49,21 @@ module.exports = { dependency };
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
-/******/ 	
+/******/
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
 /******/ 	var __webpack_exports__ = __webpack_require__(956);
-/******/ 	
+/******/
 /******/ 	return __webpack_exports__;
 /******/ })()
 ;

--- a/test/bundles/webpack5UmdBundleWithDecoyIIFE.modules.json
+++ b/test/bundles/webpack5UmdBundleWithDecoyIIFE.modules.json
@@ -1,0 +1,6 @@
+{
+  "modules": {
+    "447": "(module) {\n\nmodule.exports = \"fixture-dependency\";\n\n\n/***/ }",
+    "956": "(module, __unused_webpack_exports, __webpack_require__) {\n\nconst dependency = __webpack_require__(447);\n\nmodule.exports = { dependency };\n\n\n/***/ }"
+  }
+}

--- a/test/parseUtils.js
+++ b/test/parseUtils.js
@@ -61,6 +61,9 @@ describe("parseBundle", () => {
     const bundleFile = `${BUNDLES_DIR}/webpack5NestedModulesWithoutRuntime.js`;
 
     expect(parseBundle(bundleFile).modules).toEqual({});
+    expect(
+      parseBundle(bundleFile, { expectedModuleIds: [123] }).modules,
+    ).toEqual({});
   });
 
   it("should parse invalid bundle and return it's content and empty modules hash", () => {

--- a/test/parseUtils.js
+++ b/test/parseUtils.js
@@ -47,6 +47,22 @@ describe("parseBundle", () => {
     });
   }
 
+  it("should preserve the top-level Webpack 5 module-map fallback", () => {
+    const bundleName = "webpack5TopLevelModulesWithoutRuntime";
+    const bundleFile = `${BUNDLES_DIR}/${bundleName}.js`;
+    const expectedModules = JSON.parse(
+      fs.readFileSync(`${BUNDLES_DIR}/${bundleName}.modules.json`),
+    );
+
+    expect(parseBundle(bundleFile).modules).toEqual(expectedModules.modules);
+  });
+
+  it("should ignore nested module maps without a Webpack runtime", () => {
+    const bundleFile = `${BUNDLES_DIR}/webpack5NestedModulesWithoutRuntime.js`;
+
+    expect(parseBundle(bundleFile).modules).toEqual({});
+  });
+
   it("should parse invalid bundle and return it's content and empty modules hash", () => {
     const bundleFile = `${BUNDLES_DIR}/invalidBundle.js`;
     const bundle = parseBundle(bundleFile);

--- a/test/parseUtils.js
+++ b/test/parseUtils.js
@@ -26,6 +26,27 @@ describe("parseBundle", () => {
     });
   }
 
+  for (const [description, expectedModuleIds] of [
+    ["without module id hints", undefined],
+    ["with partial module id hints", [447]],
+    ["with tied partial module id hints", [447, 999]],
+    ["with non-matching module id hints", ["missing"]],
+  ]) {
+    it(`should ignore empty and decoy IIFEs ${description}`, () => {
+      const bundleName = "webpack5UmdBundleWithDecoyIIFE";
+      const bundleFile = `${BUNDLES_DIR}/${bundleName}.js`;
+      const expectedModules = JSON.parse(
+        fs.readFileSync(`${BUNDLES_DIR}/${bundleName}.modules.json`),
+      );
+      const bundle = parseBundle(
+        bundleFile,
+        expectedModuleIds ? { expectedModuleIds } : undefined,
+      );
+
+      expect(bundle.modules).toEqual(expectedModules.modules);
+    });
+  }
+
   it("should parse invalid bundle and return it's content and empty modules hash", () => {
     const bundleFile = `${BUNDLES_DIR}/invalidBundle.js`;
     const bundle = parseBundle(bundleFile);


### PR DESCRIPTION
**Summary**

Related to #372.

Webpack 5 UMD output nests its bootstrap IIFE inside the UMD factory. The analyzer previously missed that module map, while empty or unrelated competing IIFEs could also be selected incorrectly.

This change:

- discovers nested zero-argument Webpack bootstrap IIFEs
- ranks candidates using expected module-ID overlap and Webpack runtime structure
- excludes empty module maps
- preserves top-level and legacy parser fallbacks
- computes each asset's module metadata once
- adds Webpack 5 regression fixtures covering empty and decoy IIFEs

A patch Changeset is included.

**What kind of change does this PR introduce?**

Fix.

**Did you add tests for your changes?**

Yes. The tests cover unhinted, partially hinted, tied, and non-matching candidate selection, analyzer module-ID plumbing, and single-pass asset-module collection.

Validation:

- `npm test -- test/parseUtils.js test/analyzerUtils.js` — 27 passed
- `npm run build` — passed
- `npm run test:coverage` — 136 passed, 4 skipped
- `npm run lint` — ESLint, TypeScript, and Prettier passed
- `git diff --check` — passed

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes are required. This corrects existing bundle parsing behavior.

**Use of AI**

GitHub Copilot assisted with reproducing the failure, drafting the implementation and regression tests, and iterating on review feedback.

Human verification: I reviewed every generated change and the complete final diff, verified the behavior against Webpack 5.105.2 output, and ran all validation commands listed above. The patch also received independent review before publication. I understand the implementation and remain responsible for the contribution.
