### PR TITLE
test: add coverage for generateStatsFile and statsFilename

### DIFF
--- a/test/plugin.js
+++ b/test/plugin.js
@@ -206,6 +206,94 @@ describe("Plugin", () => {
       });
     });
 
+    describe("generateStatsFile", () => {
+      function readStats(statsFilename = "stats.json") {
+        return JSON.parse(
+          fs.readFileSync(
+            path.resolve(__dirname, `./output/${statsFilename}`),
+            "utf8",
+          ),
+        );
+      }
+
+      forEachWebpackVersion(({ it, webpackCompile }) => {
+        it("should generate a stats file", async () => {
+          const config = makeWebpackConfig({
+            analyzerOpts: {
+              analyzerMode: "disabled",
+              generateStatsFile: true,
+            },
+          });
+
+          await webpackCompile(config);
+
+          expect(readStats().assets.map((asset) => asset.name)).toContain(
+            "bundle.js",
+          );
+        });
+      });
+
+      it("should not generate a stats file by default", async () => {
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+            analyzerMode: "disabled",
+          },
+        });
+
+        await webpackCompile(config, "4");
+
+        expect(
+          fs.existsSync(path.resolve(__dirname, "./output/stats.json")),
+        ).toBe(false);
+      });
+
+      it("should support a custom `statsFilename`", async () => {
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+            analyzerMode: "disabled",
+            generateStatsFile: true,
+            statsFilename: "custom-stats.json",
+          },
+        });
+
+        await webpackCompile(config, "4");
+
+        expect(readStats("custom-stats.json").assets).toBeDefined();
+      });
+
+      it("should create missing directories for a nested `statsFilename`", async () => {
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+            analyzerMode: "disabled",
+            generateStatsFile: true,
+            statsFilename: "nested/dir/stats.json",
+          },
+        });
+
+        await webpackCompile(config, "4");
+
+        expect(readStats("nested/dir/stats.json").assets).toBeDefined();
+      });
+
+      it("should support an absolute `statsFilename`", async () => {
+        const statsFilepath = path.resolve(
+          __dirname,
+          "./output/absolute/stats.json",
+        );
+        const config = makeWebpackConfig({
+          analyzerOpts: {
+            analyzerMode: "disabled",
+            generateStatsFile: true,
+            statsFilename: statsFilepath,
+          },
+        });
+
+        await webpackCompile(config, "4");
+
+        expect(fs.existsSync(statsFilepath)).toBe(true);
+      });
+    });
+
     describe("reportTitle", () => {
       it("should have a sensible default", async () => {
         const config = makeWebpackConfig();


### PR DESCRIPTION
### What

Adds plugin-level test coverage for the `generateStatsFile` and `statsFilename` options.

### Why

Both are documented public options, but neither had any coverage at the plugin level. The existing `test/statsUtils.js` only exercises the low-level `writeStats` helper, so the option wiring in `BundleAnalyzerPlugin` was never verified by CI — including the `mkdir` call that creates missing directories for a nested `statsFilename`.

### What is covered

- `generateStatsFile: true` writes the stats file (Webpack 4 and 5)
- no stats file is written by default
- a custom relative `statsFilename`
- a nested `statsFilename`, which exercises the recursive directory creation
- an absolute `statsFilename`

The tests use `analyzerMode: "disabled"` together with `generateStatsFile: true`, which is the combination described in the README for generating only the stats file.

### Verification

`npm run lint` and the test suite both pass locally. I also confirmed the tests are meaningful by temporarily short-circuiting the `generateStatsFile` branch in `BundleAnalyzerPlugin`: the five positive tests fail and the negative one still passes.

No production code is changed in this PR.
